### PR TITLE
cleanup: remove cortex/opencode/terraform, add keycloak + misc

### DIFF
--- a/.claude/idea-analysis/2026-02-09-claude-code-linear-automated-issue-resolution.md
+++ b/.claude/idea-analysis/2026-02-09-claude-code-linear-automated-issue-resolution.md
@@ -1,0 +1,167 @@
+---
+source: https://youtu.be/jsI18Htgf8k
+date: 2026-02-09
+speaker: Unknown (indie dev / YouTuber, runs production messaging app for sales agents)
+type: idea-analysis
+verdict: Steal one piece
+viability: green
+hype-risk: yellow
+business-fit: green
+segment-fit: A
+tags: [idea-analysis, developer-workflow, claude-code, automation, linear, sub-agents]
+---
+
+# Claude Code + Linear: Automated Issue Resolution Workflow
+
+## TL;DR
+
+Workflow combining Claude Code slash commands with Linear (project management) to automate the full issue-resolution lifecycle — from fetching an issue to planning via TDD, implementing, opening a PR, running code review, fixing review issues, and updating Linear — all with a single slash command. Only manual step: initial planning/decision-making.
+
+## Scores
+
+- **Idea Viability** 🟢 **Strong** — Real productivity workflow with demonstrated results; not a product to sell but a process to adopt.
+- **Hype/BS** 🟡 **Medium risk** — Practitioner with real product, but newsletter funnel + cherry-picked demo + "hours saved" framing need scrutiny.
+- **dotslash.dev Fit** 🟢 **Strong (Segment A)** — Directly applicable to own dev workflow AND packageable as consulting IP for tech teams.
+- **Effort vs Payoff** 🟢 **High payoff** — Already have 80% of this built; marginal effort to formalize the remaining pieces.
+
+**One-liner: "You're already doing this. Steal the Linear MCP integration and the iterative review loop pattern — skip the newsletter."**
+
+## The Workflow (Detailed)
+
+### Process Diagram
+
+```
+Plan (human, 5-10 min)
+  → Fetch issue via MCP
+  → Create branch (auto-linked to Linear via naming convention)
+  → Spin up plan agent (TDD — tests first)
+  → Spin up implementation agent
+  → Commit / push / open PR
+  → Monitor PR checks (background task)
+  → PR review (sub-agent)
+  → Fix review issues (sub-agent)
+  → Re-review until approved
+  → Update Linear issue with findings
+  → Human reviews final PR and merges
+```
+
+### Key Design Decisions
+
+1. **Sub-agents for everything after planning** — keeps main context window small. Demo used ~73K tokens over 26 minutes with plenty of context left.
+2. **TDD-first in the plan agent** — writes tests before implementation, ensuring coverage before review catches remaining issues.
+3. **Branch naming convention** — includes Linear issue ID, auto-links and moves issues through statuses (backlog → in progress → in review).
+4. **Iterative review loop** — review agent flags issues → fix agent addresses them → re-review validates → repeat until approved.
+5. **Background CI monitoring** — agent watches for GitHub Actions check failures and auto-fixes.
+
+### Linear Organization
+
+- **Issues** = atomic unit of work, narrow enough for one context window
+- **Projects** = groups of related issues (e.g., "implement payments" = Stripe + DB + pricing page + checkout)
+- **Milestones** = optional grouping within projects
+- **Blocking** = Linear natively supports issue dependencies; Claude uses this for execution ordering
+
+### Slash Commands Mentioned
+
+1. **Create Linear issue** — template-based, walks through refinement until well-defined with no ambiguity. Includes: summary, current vs expected behavior, acceptance criteria, scope, root cause analysis.
+2. **Create Linear project** — 6-step workflow, creates individual issues via the issue slash command, sets up blocking relationships.
+3. **Resolve issue** — the main automation. Single command that executes the full pipeline above.
+4. **Enhance issue** — for issues created from other sources (e.g., Sentry), normalizes them to the standard template.
+
+## Viability Analysis
+
+### Why it works
+
+- Solves real pain point every developer using AI coding tools faces (babysitting through repetitive steps)
+- The steps after planning ARE deterministic and repeatable — good automation target
+- Sub-agent pattern for context preservation is genuinely clever and matches Anthropic's own recommendations
+- Demo is verifiable — real feature (read receipts) deployed to real production app
+- Linear's blocking/dependency system provides real structural advantage over ad-hoc task management
+- 26-min / 73K-token result is concrete and plausible for a well-scoped issue
+
+### Limitations not discussed
+
+- No mention of failure rate — how often does the full pipeline actually produce a shippable PR?
+- Race condition caught in review is presented as "the system works" but also reveals AI-generated code quality concerns
+- Context window management with sub-agents means each sub-agent starts with limited context about the broader system
+- Works best for well-scoped, isolated issues — complex cross-cutting changes would likely fail
+- TDD-first sounds good but AI-generated tests often test the implementation rather than the behavior
+
+## Hype/BS Detailed Assessment
+
+### Green Flags ✅
+
+- **Practitioner** — has actual production messaging app, not just teaching
+- **Shows real code** — real GitHub activity, real deployment, real PR with real review comments
+- **Intellectually honest about planning** — "no one knows your domain better than you, including any AI"
+- **Shows warts** — race condition caught in review, 5 issues found, doesn't pretend it's flawless
+- **Concrete numbers** — 26 minutes, 73K tokens, 5 review issues
+
+### Red Flags 🚩
+
+- **Newsletter funnel** — free Substack "The AI Launchpad" with prompts as the hook. Classic content-to-newsletter pipeline.
+- **Cherry-picked demo** — showed ONE successful run. No mention of failure rate, hallucinations, context window blowups, or issues the review loop didn't catch.
+- **"Saving me hours every day"** — vague time savings without baseline. How many issues/day? What's actual error rate?
+- **GitHub contribution graph as proof** — correlation ≠ causation. More commits ≠ better software.
+- **"Next step: REPL loops / multi-bot"** — teases autonomous coding without acknowledging massive reliability gap between supervised and unsupervised loops.
+- **"Anyone can do this" implied** — prompts shared on newsletter, but the effectiveness depends heavily on codebase quality, test infrastructure, CI setup, and well-written issues.
+
+### Verdict
+
+Genuine practitioner with real insights, but packaging it for content/newsletter growth. The workflow is real; the implied ease is exaggerated.
+
+## dotslash.dev Fit Analysis
+
+### Segment A (AI Consulting) — 🟢 Strong
+
+- Directly relevant to consulting offering: "here's how we set up automated dev workflows for your team" is a tangible deliverable
+- Already have slash commands (`/finalize`, `/review-pr`), sub-agent patterns, and TDD discipline — just need to formalize the end-to-end chain
+- Packageable as "developer productivity audit" or "AI workflow setup" engagement for tech teams
+- Linear MCP integration is the one missing piece — worth exploring for consulting clients using Linear
+- Demonstrates production AI expertise (one of the consulting differentiators)
+
+### Segment B (SMB Product) — 🔴 Irrelevant
+
+- Copenhagen plumbers don't need automated PR review loops
+- Pure developer tooling, no SMB application
+
+## Effort vs Payoff
+
+### Already have (80%)
+
+- ✅ Slash commands for commit, PR, review (`/finalize`)
+- ✅ Sub-agent patterns (documented in CLAUDE.md)
+- ✅ TDD discipline (jqwik property tests, test-first architecture)
+- ✅ PR review automation (`/review-pr`)
+- ✅ Atlassian MCP tools in skill list (`atlassian:triage-issue`, etc.)
+
+### Would need to add (20%)
+
+- Linear/Jira MCP integration for issue fetching + status updates
+- Single "resolve issue" slash command chaining existing commands
+- Background task monitoring for CI checks
+- Branch naming convention automation tied to issue IDs
+
+### Estimated effort
+
+~1 day to formalize into a `/resolve-issue` skill that chains existing components. ROI is in own shipping velocity + consulting IP.
+
+## What to Steal
+
+1. **The "resolve issue" orchestrator pattern** — one slash command chaining: fetch issue → branch → plan → implement → commit → PR → review → fix → re-review. Have all pieces; chain them.
+2. **Linear/Jira MCP for status automation** — branch naming conventions that auto-move issues through statuses.
+3. **Background CI monitoring** — agent watches for check failures and auto-fixes as addition to `/finalize` flow.
+4. **Issue template discipline** — issues written to be agent-resolvable without clarification. Acceptance criteria, scope boundaries, root cause analysis baked in.
+
+## What to Ignore
+
+- The newsletter and prompt sharing — own prompts are already more sophisticated (architecture rules, property testing, Either/Validation library are deeper)
+- "REPL loops / multi-bot" teaser — vaporware until proven. Unsupervised agent loops have terrible reliability at scale.
+- GitHub contribution graph flexing
+- The specific Linear choice — same pattern works with Jira, GitHub Issues, or any issue tracker with MCP/API access
+
+## Actionable Next Steps
+
+1. Build a `/resolve-issue` skill that calls `/finalize` as its final step
+2. Integrate Atlassian MCP (already available) for issue fetching and status updates
+3. Add iterative review loop to the pipeline (review → fix → re-review until clean)
+4. Package the full workflow as a consulting deliverable: "AI-automated dev pipeline setup"

--- a/.claude/ideas/gsd-patterns-for-loom.md
+++ b/.claude/ideas/gsd-patterns-for-loom.md
@@ -1,0 +1,426 @@
+# GSD (Get Shit Done) Patterns for Loom
+
+Analysis of [gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done) — a meta-prompting and context engineering framework for Claude Code — and how its patterns apply to our loom orchestration system.
+
+---
+
+## TL;DR — Condensed Summary
+
+### What GSD Is
+
+Prompt-engineering-heavy, artifact-driven framework. 6-stage cycle: init → discuss → plan → execute → verify → complete. Solves context rot via fresh 200K windows per agent, structured artifacts (PROJECT.md, STATE.md, REQUIREMENTS.md, ROADMAP.md), and goal-backward verification. No hooks — all enforcement is prompt-level.
+
+### Core Architectural Difference
+
+| | **Loom** | **GSD** |
+|---|----------|---------|
+| Enforcement | Hooks + chmod 444 (OS-level) | Prompt instructions only |
+| State | JSON state machine | Markdown files (100-line STATE.md cap) |
+| Scope | Feature-level orchestration | Full project lifecycle |
+| Trust model | Capable-but-untrustworthy (hook-enforced) | Smart-but-forgetful (artifact-persistent) |
+
+### Top 4 Ideas to Steal
+
+1. **Discussion/Gray-Area Phase** — structured ambiguity resolution before planning. Outputs locked decisions/discretion/deferred buckets. Fills brainstorm→specify weakness already identified in loom review.
+2. **Plan Validation Agent** — 7-dimension pre-execution check (requirement coverage, dependency correctness, scope sanity, etc). Loom only validates JSON schema, not whether plan achieves goals.
+3. **Goal-Backward Verification** — 4-level substance check (exists → substantive → wired → functional) + anti-stub detection. Extends wave gate beyond tests+review.
+4. **Executor Deviation Rules** — graduated autonomy (auto-fix bugs/deps, escalate structural changes). Structured protocol for unexpected situations during execution.
+
+### Secondary Ideas
+
+5. Quick mode (`--quick` flag for lightweight tasks)
+6. Checkpoint protocol during execution (human-verify/decision/human-action)
+7. Performance metrics (duration per task/wave/phase)
+8. Atomic commit enforcement per task (verify commit between start_sha and HEAD)
+9. Model profiles per agent type (opus/sonnet/haiku mapping)
+10. Compressed summaries per plan (GSD's SUMMARY.md = our clnode work_summary pattern)
+
+### What Loom Already Does Better
+
+- Hook enforcement (OS-level > prompt-level)
+- Machine-readable state (JSON > markdown parsing)
+- Spec traceability (automated anchor suggestion)
+- New test verification (git diff scan for test patterns)
+- Review integration (per-wave code review + spec-check)
+
+### Adoption Roadmap
+
+```
+Phase 1 (Quick Wins): Quick mode, deviation rules template, atomic commit check
+Phase 2 (High Impact): Discussion phase, plan validation, goal-backward verification
+Phase 3 (Polish): Checkpoints, metrics, model profiles, compressed summaries
+```
+
+---
+
+## Extended Analysis
+
+### What GSD Is
+
+A lightweight meta-prompting and context engineering framework for Claude Code, OpenCode, and Gemini CLI. Addresses "context rot" — quality degradation as Claude fills its context window — through spec-driven development with structured artifacts.
+
+**6-stage development cycle:**
+```
+/gsd:new-project  →  Deep questioning, parallel research, requirements, roadmap
+/gsd:discuss-phase →  Gray area identification, user decisions, CONTEXT.md
+/gsd:plan-phase   →  Task decomposition, plan checker validation, PLAN.md
+/gsd:execute-phase →  Wave-based parallel execution, fresh context per agent
+/gsd:verify-work  →  Goal-backward verification, substance checks
+/gsd:complete-milestone →  Archive, tag, loop to next phase
+```
+
+**Key artifacts maintained:**
+
+| Artifact | Purpose | Size Discipline |
+|----------|---------|-----------------|
+| `PROJECT.md` | Vision, always available | Stable after init |
+| `REQUIREMENTS.md` | Scoped v1/v2 requirements with REQ-IDs | Phase traceability |
+| `ROADMAP.md` | Progress tracking, completed phases | Updated per phase |
+| `STATE.md` | Decisions, blockers, session memory | **100-line limit** |
+| `PLAN.md` | Atomic XML tasks per plan | ~50% context budget |
+| `CONTEXT.md` | Discussion decisions (locked/discretion/deferred) | Per-phase |
+| `SUMMARY.md` | Execution record per plan | Committed to git |
+
+**Agent ecosystem (11 agents):**
+- `gsd-project-researcher` — 4 parallel researchers (stack, features, architecture, pitfalls)
+- `gsd-research-synthesizer` — Combines research into SUMMARY.md
+- `gsd-roadmapper` — Derives phases from requirements
+- `gsd-planner` — Task decomposition with goal-backward methodology
+- `gsd-plan-checker` — Pre-execution plan validation (7 dimensions)
+- `gsd-executor` — Task execution with deviation handling + checkpoints
+- `gsd-verifier` — Post-execution goal-backward verification
+- `gsd-debugger` — Scientific root cause analysis with persistent state
+- `gsd-codebase-mapper` — Brownfield convention discovery
+- `gsd-integration-checker` — Cross-component wiring validation
+
+### Architecture Comparison — Deep Dive
+
+#### Phase Flow Mapping
+
+```
+GSD                         Loom                        Delta
+───────────────────         ───────────────────         ─────────
+new-project (research)      brainstorm                  GSD: 4 parallel researchers
+                                                        Loom: single agent
+discuss-phase               (no equivalent)             GSD: structured gray areas
+                                                        Loom: GAP — weakest handoff
+plan-phase                  specify + architecture      GSD: plan checker validates
+  + plan-checker            + decompose                 Loom: schema-only validation
+execute-phase               execute (waves)             Similar wave-based parallel
+                                                        GSD: deviation rules, checkpoints
+                                                        Loom: hook-enforced, auto-retry
+verify-work                 wave-gate                   GSD: goal-backward (4 levels)
+                                                        Loom: tests + review + spec
+complete-milestone          /loom --complete            GSD: archive + tag
+                                                        Loom: cleanup + PR
+```
+
+#### Enforcement Model
+
+**GSD**: All enforcement via prompt instructions. Agents are told "you MUST do X" but nothing physically prevents violations. Relies on LLM compliance.
+
+**Loom**: Hook-enforced via TypeScript handlers. State file has chmod 444 OS protection. PreToolUse hooks block Edit/Write/MultiEdit calls. Phase ordering physically enforced — agents can't skip phases even if they "want" to.
+
+**Implication**: GSD's patterns can be adopted at the **prompt level** (templates) or **promoted to hook enforcement** for critical guarantees.
+
+#### State Management
+
+**GSD**: Markdown-based (STATE.md, 100 lines max). Parsed with regex/frontmatter. Human-readable but fragile. Uses `gsd-tools.js` CLI (~50 atomic commands) for CRUD operations.
+
+**Loom**: JSON state machine with typed fields. `StateManager` class with atomic writes and file locking. Machine-readable, hook-writable only. More robust but less human-inspectable.
+
+**Insight**: GSD's 100-line STATE.md constraint is smart context engineering — forces compression. Our JSON state can grow unbounded. Consider adding a max-size check.
+
+### Stealable Patterns — Detailed
+
+#### Pattern 1: Discussion/Gray-Area Phase (HIGH VALUE)
+
+**What GSD does**: Before planning, `discuss-phase` identifies **gray areas** — specific decisions that could go multiple ways. Not generic ("how should UI look?") but concrete ("Cards vs list view? Duplicate handling strategy? Folder naming convention?").
+
+For each selected area:
+1. Announce topic clearly
+2. Ask 4 focused questions with concrete options
+3. Check satisfaction
+4. Repeat if needed
+
+Output: `CONTEXT.md` with three buckets:
+- **User decisions** (locked — downstream agents honor exactly)
+- **Claude's Discretion** (flexibility exists)
+- **Deferred ideas** (noted for future phases)
+
+**Why loom needs this**: The 2026-02-06 loom review identified brainstorm→specify as the weakest handoff. Free-form brainstorm text doesn't translate cleanly to structured spec requirements. A discuss phase bridges this gap by forcing concrete decisions before specification.
+
+**Scope protection**: When users suggest out-of-scope features during discussion, GSD redirects without dismissing: "[Feature] sounds like a new capability — that belongs in its own phase. I'll note it as a deferred idea."
+
+**Implementation options**:
+1. New `discuss-agent` between brainstorm and specify
+2. Enhance `clarify-agent` to run pre-specify (currently only post-specify)
+3. Add discussion prompts to `phase-specify.md` template (lightest touch)
+
+**New state fields**:
+```json
+{
+  "phase_artifacts": {
+    "brainstorm": "completed",
+    "discuss": ".claude/specs/{slug}/decisions.md",
+    "specify": null
+  }
+}
+```
+
+#### Pattern 2: Plan Validation Agent (HIGH VALUE)
+
+**What GSD does**: `gsd-plan-checker` runs before execution and validates 7 dimensions:
+
+1. **Requirement coverage** — every phase requirement has corresponding tasks
+2. **Task completeness** — all required fields present (files, action, verify, done)
+3. **Dependency correctness** — valid acyclic graphs, no cycles
+4. **Key links planned** — artifacts wired together, not isolated
+5. **Scope sanity** — fits context budget (2-3 tasks/plan optimal)
+6. **Verification derivation** — must_haves reflect user-observable outcomes
+7. **Context compliance** — honors locked decisions from CONTEXT.md
+
+Returns PASSED or ISSUES FOUND with blocker/warning/info levels.
+
+**Why loom needs this**: `validate-task-graph` only checks JSON schema (correct types, required fields). It doesn't check whether the plan will achieve the spec requirements. A task graph can be schema-valid but produce zero useful code.
+
+**Implementation options**:
+1. New `validate-plan-agent` spawned between decompose and execute
+2. Enhanced `validate-task-graph` helper with spec-coverage check
+3. Add validation prompts to decompose-agent output requirements
+
+**Key checks to add**:
+- Every spec anchor (FR-xxx) mapped to at least one task
+- No dependency cycles in wave graph
+- File ownership doesn't overlap between parallel tasks
+- Task descriptions are specific (not "add authentication" but "create POST /api/auth/login")
+
+#### Pattern 3: Goal-Backward Verification (HIGH VALUE)
+
+**What GSD does**: The `gsd-verifier` doesn't ask "did tasks complete?" — it asks "does the codebase deliver promised functionality?" through 4 levels:
+
+```
+Level 1: EXISTS       — File at expected path?
+Level 2: SUBSTANTIVE  — Real code, not stubs? (anti-stub detection)
+Level 3: WIRED        — Imported and used in the system?
+Level 4: FUNCTIONAL   — Actually works when invoked?
+```
+
+**Anti-stub detection patterns**:
+- Comment-based: TODO, FIXME, "coming soon", ellipsis
+- Placeholder text: "lorem ipsum", "under construction", template brackets
+- Trivial implementations: return null/undefined/empty, only console.log
+- Hardcoded values: static IDs, counts where dynamic expected
+
+**Wiring verification**:
+- Component → API: fetch/axios calls exist, responses consumed
+- API → Database: queries execute with await, results in response
+- Form → Handler: submit handlers invoke actual mutations
+- State → Render: JSX uses state variables dynamically
+
+**Why loom needs this**: Wave gate checks tests + review + spec-alignment, but:
+- A test can pass with trivial implementation
+- A review can miss stubs if reviewer is superficial
+- Spec-check validates coverage, not substance
+
+**Implementation options**:
+1. 6th wave gate check: `substance_verified`
+2. Enhance spec-check agent to include substance checks
+3. Separate `verify-substance` helper in wave-gate flow
+
+#### Pattern 4: Executor Deviation Rules (HIGH VALUE)
+
+**What GSD does**: 4-rule framework for executor autonomy:
+
+| Rule | Trigger | Action |
+|------|---------|--------|
+| 1 | Code doesn't work as intended | Auto-fix bugs inline |
+| 2 | Missing essential for correctness/security | Auto-add critical functionality |
+| 3 | Blocking issue (dependency, import, env var) | Auto-fix |
+| 4 | Structural modification required | **STOP → checkpoint with proposal** |
+
+Rules 1-3 require no permission. Rule 4 demands explicit decision before proceeding.
+
+All deviations logged in SUMMARY.md with rule category and fix details.
+
+**Why loom needs this**: Impl agents have no structured protocol for unexpected situations. They either succeed or fail — binary outcome. No graduated autonomy, no deviation logging.
+
+**Implementation**:
+- Add deviation rules to `impl-agent-context.md` template (prompt-level, no hooks needed)
+- Add `deviations` field to task state (populated by update-task-status from transcript)
+- Optional: hook that detects Rule 4 escalation and pauses execution
+
+#### Pattern 5: Quick Mode (MEDIUM VALUE)
+
+**What GSD does**: `/gsd:quick` for ad-hoc tasks:
+- Single plan, 1-3 tasks max
+- ~30% context budget
+- Skips research, plan checking, verification
+- Separate tracking in `.planning/quick/`
+- Tracked in STATE.md but doesn't block planned work
+
+**Why loom needs this**: Currently all-or-nothing. A simple "add logout button" goes through brainstorm→specify→clarify→arch→decompose→execute. With --skip flags it's still clunky. Quick mode would:
+- Skip all pre-execute phases
+- Create single-wave plan inline (no decompose agent)
+- Relaxed wave gate (no spec-check, optional review)
+- No GitHub issue
+
+**Implementation**: `/loom --quick "description"` flag. Bypass hook enforcement by not creating state file, or create minimal state with `quick_mode: true` that relaxes hook checks.
+
+#### Pattern 6: Checkpoint Protocol (MEDIUM VALUE)
+
+**What GSD does**: 3 checkpoint types during execution:
+
+| Type | Frequency | Purpose |
+|------|-----------|---------|
+| `human-verify` | 90% | Confirm visual/functional correctness |
+| `decision` | 9% | Choose between implementation options |
+| `human-action` | 1% | Unavoidable manual step (OAuth, email verify) |
+
+Executor pauses, presents structured state (completed tasks, current position), waits for user response, then resumes with fresh agent and explicit continuation state.
+
+**Why loom needs this**: During execute phase, loom is fully autonomous. No mid-wave pause mechanism. If an agent encounters an auth gate or needs a design decision, it either fails or makes assumptions.
+
+**Implementation**:
+- Add `checkpoint_type` field to task state
+- Detect checkpoint signals in SubagentStop transcript parsing
+- Pause wave execution, present to user
+- Resume with continuation context
+
+#### Pattern 7: Performance Metrics (MEDIUM VALUE)
+
+**What GSD does**: Tracks per-plan execution duration, completion counts, trend analysis (improving/stable/degrading). Stored in STATE.md performance section.
+
+**Why useful**: Enables velocity tracking, bottleneck identification, and evidence-based model allocation. "Architecture agents take 3x longer than impl agents" → move arch to opus, impl to sonnet.
+
+**Implementation**: Add `started_at`/`completed_at` timestamps to task state. Calculate durations in wave-gate or complete hooks. Store aggregate metrics.
+
+#### Pattern 8: Atomic Commit Enforcement (MEDIUM VALUE)
+
+**What GSD does**: Each task gets independent commit:
+- Stage only task-related files (never `git add .`)
+- Format: `{type}({phase}-{plan}): {description}`
+- Record commit hash in SUMMARY.md
+- Enables git bisect and independent revert
+
+**Why loom needs this**: Already have `start_sha` stored by `validate-task-execution.sh`. Could verify a commit exists between `start_sha` and current HEAD in `update-task-status.sh`. Currently no enforcement — agents may or may not commit.
+
+**Implementation**: In `update-task-status.ts`, check `git log start_sha..HEAD --oneline | wc -l`. If 0, set `committed: false` warning. Don't block — some agents legitimately don't commit (test-only tasks).
+
+#### Pattern 9: Model Profiles (LOW VALUE)
+
+**What GSD does**: Maps agent types to model tiers based on profile:
+
+```
+quality:   planner=opus,  executor=opus,   verifier=sonnet
+balanced:  planner=opus,  executor=sonnet, verifier=sonnet
+budget:    planner=sonnet, executor=sonnet, verifier=haiku
+```
+
+**Implementation**: Add `model` field to Task tool spawning in loom templates. Map from agent type. Already partially handled by Claude Code's model parameter.
+
+#### Pattern 10: Session Continuity (LOW VALUE)
+
+**What GSD does**: STATE.md captures last session timestamp, final action, and pointer to `.continue-here` resume file. Structured `/clear` guidance explains context window management.
+
+**Why partially covered**: Loom's `cleanup-stale-subagents.sh` handles stale tracking files. State file persists across sessions. But no structured "here's exactly where you left off" format.
+
+### Patterns NOT Worth Adopting
+
+#### Parallel Research Agents (4 agents at init)
+
+GSD spawns 4 researchers (stack, features, architecture, pitfalls) in parallel. Loom's brainstorm is a single agent. While impressive, this is:
+- Expensive (4× opus/sonnet calls)
+- Designed for greenfield projects (Loom is feature-level, not project-level)
+- Brainstorm + specify already covers feature-level research adequately
+
+**Verdict**: Skip. Different scope.
+
+#### Markdown-Based State
+
+GSD uses STATE.md (100-line cap) parsed with regex. Our JSON + StateManager is more robust, machine-readable, and hook-writable. Would be a regression.
+
+**Verdict**: Skip. JSON state is strictly better for hook-based systems.
+
+#### gsd-tools.js CLI (~50 commands)
+
+GSD has a monolithic CLI for all state operations. Our `cli.ts` with handler routing + StateManager is more modular and type-safe.
+
+**Verdict**: Skip. Our architecture is cleaner.
+
+#### Brownfield Mode (map-codebase)
+
+GSD's `/gsd:map-codebase` spawns agents to analyze existing code. Loom agents already explore codebases naturally via the Explore subagent type. Not needed as a formal phase.
+
+**Verdict**: Skip. Already covered implicitly.
+
+### Integration with Existing Loom Enhancements
+
+These GSD patterns complement the clnode patterns already planned:
+
+```
+clnode patterns              GSD patterns
+───────────────              ────────────
+work_summary (SubagentStop)  ← feeds → Goal-backward verification (substance check)
+context injection (Start)    ← feeds → Deviation awareness (prior agent decisions)
+compression (Haiku)          ← feeds → Performance metrics (context budget tracking)
+```
+
+**Combined data flow**:
+```
+Discussion phase → decisions.md (GSD)
+  → Spec with locked decisions
+    → Plan validated pre-execute (GSD)
+      → Agent spawns with injected context (clnode)
+        → Agent follows deviation rules (GSD)
+          → SubagentStop: compress summary (clnode) + extract deviations (GSD)
+            → Wave gate: tests + review + spec + substance check (GSD)
+              → Metrics recorded (GSD)
+```
+
+### Adoption Roadmap
+
+#### Phase 1: Quick Wins (prompt-level, no new hooks)
+
+1. **Quick mode** — `/loom --quick` flag, bypass pre-execute phases
+2. **Deviation rules** — Add rules 1-4 to `impl-agent-context.md` template
+3. **Atomic commit check** — Warning in `update-task-status.ts` if no commit found
+4. **Task specificity requirement** — Add to decompose template: "reject vague tasks"
+
+#### Phase 2: High Impact (new hooks/agents)
+
+5. **Discussion phase** — New phase between brainstorm and specify (or enhanced clarify)
+6. **Plan validation** — New hook or agent between decompose and execute
+7. **Goal-backward verification** — Substance checks in wave gate
+8. **Deviation logging** — New `deviations` field in task state, parsed from transcript
+
+#### Phase 3: Polish
+
+9. **Checkpoint protocol** — Mid-execution pause/resume mechanism
+10. **Performance metrics** — Duration tracking per task/wave
+11. **Model profiles** — Agent-to-model mapping with quality/balanced/budget profiles
+12. **Compressed summaries** — (Already planned from clnode analysis)
+
+### Cost Analysis
+
+| Pattern | Implementation Cost | Ongoing Cost | Value |
+|---------|-------------------|--------------|-------|
+| Discussion phase | New agent/template | ~$0.50/run | HIGH |
+| Plan validation | New agent or enhanced helper | ~$0.30/run | HIGH |
+| Goal-backward verification | Enhanced wave gate | ~$0.20/run | HIGH |
+| Deviation rules | Template change only | $0 | HIGH |
+| Quick mode | Flag + skip logic | $0 | MEDIUM |
+| Checkpoints | New hook handler | $0 | MEDIUM |
+| Metrics | Field additions | $0 | MEDIUM |
+| Commit enforcement | Enhanced hook | $0 | MEDIUM |
+
+## Unresolved Questions
+
+- Discussion phase: new agent or enhance existing clarify-agent?
+- Quick mode: same hooks active (relaxed) or bypass entirely (no state file)?
+- Plan validation: separate agent or enhanced validate-task-graph helper?
+- Goal-backward verification: new wave gate check or extend spec-check agent?
+- Deviation rules: prompt-only or enforce via hooks (new SubagentStop handler)?
+- Substance checks: how to detect stubs without high false-positive rate?
+- Checkpoint resume: fresh agent with state or same agent continuation?
+- Discussion + clarify overlap: merge into single "resolve ambiguity" phase?

--- a/.claude/skills/entity-generator/SKILL.md
+++ b/.claude/skills/entity-generator/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: entity-generator
+description: "Generate JPA entity classes from Oracle CREATE TABLE DDL statements. Use when the user provides a CREATE TABLE definition and wants a Hibernate entity. Handles Oracle types (VARCHAR2, NUMBER, CLOB, CHAR, DATE, TIMESTAMP, BLOB), schema-qualified tables, and follows the hibertable11 repo conventions."
+user_invocable: true
+---
+
+# Entity Generator Skill
+
+Generate JPA entity classes from Oracle `CREATE TABLE` DDL following hibertable11 conventions.
+
+## Input
+
+User provides a `CREATE TABLE` statement. Example:
+
+```sql
+CREATE TABLE RATOR.WF_ACTION_CONFIG
+(
+  UUID           CHAR(36 CHAR)                  NOT NULL,
+  ACTION         VARCHAR2(256 CHAR),
+  CONFIG         CLOB,
+  CONFIG_FORMAT  VARCHAR2(256 CHAR),
+  ID             NUMBER
+)
+```
+
+## Generation Rules
+
+### 1. Package Placement
+
+Determine package from table name prefix or schema:
+- Table starts with `OI_` → `dk.secondbrand.hibertable11.domain.entity.oister`, class prefixed `Oi`
+- Table starts with `FLEXII_` → `dk.secondbrand.hibertable11.domain.entity.flexii`, class prefixed `Flexii`
+- Otherwise → `dk.secondbrand.hibertable11.domain.entity.shared`
+
+If the table name has a known prefix like `WF_`, `DK2_`, `GENERIC_` — keep it in `shared` unless user specifies.
+
+**Ask the user** if placement is ambiguous.
+
+### 2. Class Name Derivation
+
+Convert `UPPER_SNAKE_CASE` table name to `PascalCase`:
+- Remove schema prefix (e.g., `RATOR.`)
+- Remove brand prefix (`OI_`, `FLEXII_`) — it becomes the class prefix
+- `WF_ACTION_CONFIG` → `WfActionConfig`
+- `OI_ACCOUNT` → `OiAccount`
+- `FLEXII_USER` → `FlexiiUser`
+- `PROVISIONING_LOG` → `ProvisioningLog`
+
+### 3. Class Structure (exact annotation order)
+
+```java
+package dk.secondbrand.hibertable11.domain.entity.<subpackage>;
+
+import dk.secondbrand.hibertable11.utils.NextOidGenerator;
+import jakarta.persistence.*;
+import lombok.*;
+
+// Add java.time imports only if date/timestamp columns exist
+// Add java.math.BigDecimal only if NUMBER with scale > 0
+
+@Entity
+@Table(name = "TABLE_NAME")              // Add schema = "SCHEMA" if schema-qualified
+@Getter
+@Setter
+@ToString                                 // Add exclude = {"field"} for @Lob and relationship fields
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClassName {
+
+    @Id
+    @NextOidGenerator
+    @Column(name = "ID", nullable = false)
+    private Long id;
+
+    // ... fields ...
+}
+```
+
+### 4. Oracle → Java Type Mapping
+
+| Oracle Type | Java Type | @Column Attributes |
+|---|---|---|
+| `NUMBER` (no precision) | `Long` | — |
+| `NUMBER(p)` where p ≤ 9 | `Integer` | — |
+| `NUMBER(p)` where p > 9, scale=0 | `Long` | — |
+| `NUMBER(p,s)` where s > 0 | `BigDecimal` | `precision = p, scale = s` |
+| `VARCHAR2(n CHAR)` or `VARCHAR2(n)` | `String` | `length = n` |
+| `CHAR(n CHAR)` or `CHAR(n)` | `String` | `length = n` |
+| `CLOB` | `String` | Add `@Lob` on separate line above `@Column` |
+| `BLOB` | `byte[]` | Add `@Lob` + `@Basic(fetch = FetchType.LAZY)` |
+| `DATE` | `LocalDateTime` | — |
+| `TIMESTAMP` | `LocalDateTime` | — |
+| `TIMESTAMP WITH TIME ZONE` | `LocalDateTime` | — |
+| `RAW(16)` | `String` | `length = 32` (hex representation) |
+
+### 5. Field Name Derivation
+
+Convert `UPPER_SNAKE_CASE` column name to `camelCase`:
+- `STATUS_ID` → `statusId`
+- `CREATE_DATE` → `createDate`
+- `UUID` → `uuid`
+- `CONFIG_FORMAT` → `configFormat`
+
+### 6. ID Column Handling
+
+- If table has an `ID NUMBER` column → standard `@Id @NextOidGenerator @Column(name = "ID", nullable = false) private Long id;`
+- If table has NO `ID` column but has a `UUID CHAR(36)` → use UUID as primary key:
+  ```java
+  @Id
+  @Column(name = "UUID", length = 36, nullable = false)
+  private String uuid;
+  ```
+  (No `@NextOidGenerator` — UUID is externally assigned)
+- If table has BOTH `ID` and `UUID` → `ID` is the `@Id` with `@NextOidGenerator`, `UUID` is a regular field
+
+### 7. NOT NULL Handling
+
+- If column is `NOT NULL` → add `nullable = false` to `@Column`
+- Exception: `ID` column already has `nullable = false` by convention
+
+### 8. Schema Handling
+
+If table is schema-qualified (e.g., `RATOR.TABLE_NAME`):
+```java
+@Table(name = "TABLE_NAME", schema = "RATOR")
+```
+
+### 9. @Lob Fields
+
+For CLOB/BLOB columns:
+```java
+@Lob
+@Column(name = "CONFIG")
+private String config;
+```
+
+Add the field name to `@ToString(exclude = {"config"})` to avoid lazy-load issues.
+
+### 10. Relationship Resolution for FK Columns
+
+For every column ending in `_ID` that is NOT the primary key, **you MUST search the existing codebase** to check if a matching entity already exists.
+
+**Lookup procedure:**
+1. Take the column name, strip the `_ID` suffix → candidate table name (e.g., `WORKFLOW_ID` → `WORKFLOW`)
+2. Also try with common prefixes: `OI_`, `FLEXII_`, `WF_`, `GENERIC_` (e.g., `WF_WORKFLOW`)
+3. Search for existing entities: use Grep/Glob to find `@Table(name = "WORKFLOW"` or `@Table(name = "WF_WORKFLOW"` etc. across `src/main/java/**/entity/**/*.java`
+4. Also check if the column name itself matches a known table (e.g., `PROVISIONING_TASK_ID` → look for table `PROVISIONING_TASK`)
+
+**If a matching entity IS found:**
+Generate the full relationship following repo conventions — raw FK Long + read-only `@ManyToOne`:
+```java
+@Column(name = "WORKFLOW_ID")
+private Long workflowId;
+
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "WORKFLOW_ID", insertable = false, updatable = false)
+private Workflow workflow;
+```
+- Add the relationship field name to `@ToString(exclude = {...})` to avoid lazy-load issues
+- Import the entity class if it's in a different package
+
+**If NO matching entity is found:**
+Leave a commented-out relationship hint:
+```java
+@Column(name = "WORKFLOW_ID")
+private Long workflowId;
+
+// TODO: Add relationship if entity exists
+// @ManyToOne(fetch = FetchType.LAZY)
+// @JoinColumn(name = "WORKFLOW_ID", insertable = false, updatable = false)
+// private Workflow workflow;
+```
+
+**Special cases:**
+- `STATUS_ID` → check for `Status` entity (table `STATUS` or `STATUS_TYPES`)
+- `BRAND_ID` → typically no entity, leave as raw Long with no TODO
+- Column name matches table in DDL being processed (self-referential) → use same class
+
+### 11. Import Rules
+
+Only import what's needed:
+- Always: `jakarta.persistence.*`, `lombok.*`, `NextOidGenerator` (if ID column uses it)
+- Conditionally: `java.time.LocalDateTime` (date/timestamp cols), `java.math.BigDecimal` (decimal cols)
+
+### 12. File Output Location
+
+Write entity to: `src/main/java/dk/secondbrand/hibertable11/domain/entity/<subpackage>/<ClassName>.java`
+
+## Example Output
+
+Given:
+```sql
+CREATE TABLE RATOR.WF_ACTION_CONFIG
+(
+  UUID           CHAR(36 CHAR)                  NOT NULL,
+  ACTION         VARCHAR2(256 CHAR),
+  CONFIG         CLOB,
+  CONFIG_FORMAT  VARCHAR2(256 CHAR),
+  ID             NUMBER
+)
+```
+
+Produces:
+```java
+package dk.secondbrand.hibertable11.domain.entity.shared;
+
+import dk.secondbrand.hibertable11.utils.NextOidGenerator;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "WF_ACTION_CONFIG", schema = "RATOR")
+@Getter
+@Setter
+@ToString(exclude = {"config"})
+@NoArgsConstructor
+@AllArgsConstructor
+public class WfActionConfig {
+
+    @Id
+    @NextOidGenerator
+    @Column(name = "ID", nullable = false)
+    private Long id;
+
+    @Column(name = "UUID", length = 36, nullable = false)
+    private String uuid;
+
+    @Column(name = "ACTION", length = 256)
+    private String action;
+
+    @Lob
+    @Column(name = "CONFIG")
+    private String config;
+
+    @Column(name = "CONFIG_FORMAT", length = 256)
+    private String configFormat;
+}
+```
+
+## Field Ordering
+
+1. `@Id` field always first
+2. Then remaining fields in the order they appear in the CREATE TABLE (excluding ID which was moved to top)
+
+## Multiple Tables
+
+If user provides multiple CREATE TABLE statements, generate one entity per table. Ask about shared base classes if tables have identical column subsets.
+
+## Inheritance Detection
+
+If two tables (e.g., `OI_MAIL_MESSAGE` and `FLEXII_MAIL_MESSAGE`) share most columns:
+- Suggest a `@MappedSuperclass` base in `shared/`
+- Concrete entities in `oister/` and `flexii/` extending it
+- Use `@SuperBuilder` + `@NoArgsConstructor` instead of `@AllArgsConstructor`


### PR DESCRIPTION
## Summary
- Remove cortex plugin engine (entire `plugins/cortex/` tree)
- Remove opencode task-planner plugin
- Remove terraform-homelab configs (migrated to ArgoCD)
- Add ArgoCD keycloak deployment w/ external secrets
- Add entity-generator skill
- Add idea docs (linear automation, YC sales, GSD patterns)
- Loom hooks cleanup: remove unused helpers, simplify handlers
- Misc nix role tweaks (cloudflared, k3s, ssh, bluetooth, sops)
- Update flake inputs
- Delete old plans/specs (cortex brainstorm, scalable-purring-robin, etc.)

## Test plan
- [ ] `nix flake check` passes
- [ ] home-manager builds for hansen142
- [ ] ArgoCD keycloak app syncs on homelab