### PR TITLE
fix(xmonad): add true fullscreen toggle

### DIFF
--- a/roles/home-manager/window-manager/xmonad/xmonad.hs
+++ b/roles/home-manager/window-manager/xmonad/xmonad.hs
@@ -368,7 +368,9 @@ barFull = avoidStruts $ Simplest
 
 myLayoutHook = showWorkspaceName
              -- $ onWorkspace "AV" floatWorkSpace
-             $ fullscreenFloat -- fixes floating windows going full screen, while retaining "bounded" fullscreen
+             -- Hide borders only for app-requested fullscreen floats.  Keep
+             -- normal tiling borders, but let fullscreen cover xmobar cleanly.
+             $ lessBorders OnlyScreenFloat
              $ fullScreenToggle
              $ fullBarToggle
              $ mirrorToggle
@@ -381,7 +383,7 @@ myLayoutHook = showWorkspaceName
 
     -- floatWorkSpace      = simplestFloat
     fullBarToggle       = mkToggle (single FULLBAR)
-    fullScreenToggle    = mkToggle (single FULL)
+    fullScreenToggle    = mkToggle (single NBFULL)
     mirrorToggle        = mkToggle (single MIRROR)
     reflectToggle       = mkToggle (single REFLECTX)
     smallMonResWidth    = 1920
@@ -663,7 +665,6 @@ myScratchpads =
 myHandleEventHook = docksEventHook
                 <+> fadeWindowsEventHook
                 <+> handleEventHook def
-                <+> XMonad.Layout.Fullscreen.fullscreenEventHook
  
 forceCenterFloat :: ManageHook
 forceCenterFloat = doFloatDep move
@@ -681,7 +682,6 @@ myManageHook :: ManageHook
 myManageHook =
         manageDocks
     <+> namedScratchpadManageHook myScratchpads
-    <+> fullscreenManageHook
     <+> manageSpawn
   
 myLogHook :: X ()
@@ -707,7 +707,7 @@ myKeys =
         , ("M-S-<Backspace>", killAll)                         -- Kill all windows on current workspace
 
     -- Floating windows
-    --  , ("M-f", sendMessage (MT.Toggle "floats"))       -- Toggles my 'floats' layout
+        , ("M-f", sendMessage $ MT.Toggle NBFULL)       -- True windowed fullscreen: no bar, no border
         , ("M-<Delete>", withFocused $ windows . W.sink) -- Push floating window back to tile
         , ("M-S-<Delete>", sinkAll)                      -- Push ALL floating windows to tile
 
@@ -816,6 +816,7 @@ main = do
     -- the xmonad, ya know...what the WM is named after!
     xmonad $ dynamicProjects projects
            $ withNavigation2DConfig myNav2DConf
+           $ ewmhFullscreen
            $ ewmh def
         { manageHook = myManageHook
         -- Run xmonad commands from command line with "xmonadctl command". Commands include:


### PR DESCRIPTION
## Summary
- add Super-f fullscreen toggle using no-border Full layout
- enable EWMH fullscreen handling for app-requested fullscreen
- hide borders for screen-sized fullscreen floats while keeping normal tiling borders

## Validation
- nix build .#legacyPackages.x86_64-linux.homeManagerConfigurations.peterstorm.activationPackage --no-link
- nix-shell -p 'haskellPackages.ghcWithPackages (p: [ p.xmonad p.xmonad-contrib p.xmonad-extras ])' --run 'ghc -fno-code roles/home-manager/window-manager/xmonad/xmonad.hs'